### PR TITLE
rpi/API authentication

### DIFF
--- a/raspberry-pi/flask/SmartBlindServer/Core/authentication.py
+++ b/raspberry-pi/flask/SmartBlindServer/Core/authentication.py
@@ -1,0 +1,13 @@
+import json
+from flask_httpauth import HTTPTokenAuth
+
+
+auth = HTTPTokenAuth(scheme="Bearer")
+
+@auth.verify_token
+def verify_token(token):
+    with open("SmartBlindServer/Core/tokens.json") as file:
+        tokens = json.load(file)
+    
+        if token in tokens:
+            return tokens[token]

--- a/raspberry-pi/flask/SmartBlindServer/Core/tokens.json
+++ b/raspberry-pi/flask/SmartBlindServer/Core/tokens.json
@@ -1,0 +1,3 @@
+{
+    "jason-token": "Token for Jason"
+}

--- a/raspberry-pi/flask/SmartBlindServer/Endpoints/Blind/close.py
+++ b/raspberry-pi/flask/SmartBlindServer/Endpoints/Blind/close.py
@@ -1,5 +1,8 @@
 from flask_restful import Resource
+from SmartBlindServer.Core.authentication import auth
+
 
 class BlindCloseResource(Resource):
+    @auth.login_required
     def put(self):
         return {"result": "closed"}

--- a/raspberry-pi/flask/SmartBlindServer/Endpoints/Blind/open.py
+++ b/raspberry-pi/flask/SmartBlindServer/Endpoints/Blind/open.py
@@ -1,5 +1,8 @@
 from flask_restful import Resource
+from SmartBlindServer.Core.authentication import auth
+
 
 class BlindOpenResource(Resource):
+    @auth.login_required
     def put(self):
         return {"result": "opened"}

--- a/raspberry-pi/flask/SmartBlindServer/Endpoints/Blind/status.py
+++ b/raspberry-pi/flask/SmartBlindServer/Endpoints/Blind/status.py
@@ -1,5 +1,8 @@
 from flask_restful import Resource
+from SmartBlindServer.Core.authentication import auth
+
 
 class BlindStatusResource(Resource):
+    @auth.login_required
     def get(self):
         return {"status": "open"}

--- a/raspberry-pi/flask/requirements.txt
+++ b/raspberry-pi/flask/requirements.txt
@@ -1,6 +1,7 @@
 aniso8601==8.1.1
 click==7.1.2
 Flask==1.1.2
+Flask-HTTPAuth==4.2.0
 Flask-RESTful==0.3.8
 itsdangerous==1.1.0
 Jinja2==2.11.3


### PR DESCRIPTION
Implements Bearer Token authentication for the REST API

- Utilizes `flask_HTTPAuth` Python package
- Tokens are defined in `raspberry-pi/SmartBlindServer/Core/tokens.json`